### PR TITLE
fix(pr template): clarify author section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,3 @@
-
 ticket: DV-none
 ****
 ^^^^^ Commit body above, PR title is the commit subject

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,11 +9,6 @@ ticket: DV-none
 Describe what the PR DOES in the commit body above.
 Put notes on how to test in this section.
 
-### Fix
-If this is a fix, there should be a simple test of "this doesn't work on develop, does work on the fix branch"
-
-### Feature
-If manual testing is required, please fill out this table:
 | Test Case                                    | How to tell if it works |
 | ---                                          | ---                     |
 | appfoo handles a PSM with no path prediction | Outputs empty fields    |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,11 @@ ticket: DV-none
 <!--commit body should be wrapped at 72 chars as long as this comment-->
 
 
-## Author Section
-<!-- Please only include the relevant section -->
+## Testing notes from the author
+<!--
+This section is for notes on how to test or comments abou the review.
+Please put any additional description about what the PR does in the commit body.
+-->
 
 ### Fix
 If this is a fix, there should be a simple test of "this doesn't work on develop, does work on the fix branch"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,15 @@
 ticket: DV-none
 ****
-^^^^^ Commit body above, PR title is the commit subject
 <!--commit body should be wrapped at 72 chars as long as this comment-->
+<!--
+Describe what the PR DOES in the commit body above.
+Put notes on how to test in the testing section below.
+-->
 
 
 ## Testing notes from the author
-<!--
-Describe what the PR DOES in the commit body above.
-Put notes on how to test in this section.
 
+<!--
 | Test Case                                    | How to tell if it works |
 | ---                                          | ---                     |
 | appfoo handles a PSM with no path prediction | Outputs empty fields    |
@@ -16,6 +17,8 @@ Put notes on how to test in this section.
 -->
 
 ## Reviewer Section
+* [ ] Does the PR title clearly describe what the PR does?
+* [ ] Does the commit body describe what happened in required detail? (this may be none detail)
 * [ ] Are there no breaking changes / are the breaking changes documented?
 * [ ] Are unit tests added? (or not applicable)
 * [ ] Do the edited sections of code match our coding standards

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,10 @@ ticket: DV-none
 <!--commit body should be wrapped at 72 chars as long as this comment-->
 
 
-## Testing notes from the author
 <!--
-This section is for notes on how to test or comments abou the review.
+Add this section for notes on how to test or comments about the review.
 Please put any additional description about what the PR does in the commit body.
--->
+## Testing notes from the author
 
 ### Fix
 If this is a fix, there should be a simple test of "this doesn't work on develop, does work on the fix branch"
@@ -20,7 +19,7 @@ If manual testing is required, please fill out this table:
 | ---                                          | ---                     |
 | appfoo handles a PSM with no path prediction | Outputs empty fields    |
 | appfoo handles a PSM with path prediction    | Outputs filled fields   |
-
+-->
 
 ## Reviewer Section
 * [ ] Are there no breaking changes / are the breaking changes documented?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,10 @@ ticket: DV-none
 <!--commit body should be wrapped at 72 chars as long as this comment-->
 
 
-<!--
-Add this section for notes on how to test or comments about the review.
-Please put any additional description about what the PR does in the commit body.
 ## Testing notes from the author
+<!--
+Describe what the PR DOES in the commit body above.
+Put notes on how to test in this section.
 
 ### Fix
 If this is a fix, there should be a simple test of "this doesn't work on develop, does work on the fix branch"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+
+
 ticket: DV-none
 ****
 <!--commit body should be wrapped at 72 chars as long as this comment-->
@@ -17,12 +19,13 @@ Put notes on how to test in the testing section below.
 -->
 
 ## Reviewer Section
-* [ ] Does the PR title clearly describe what the PR does?
-* [ ] Does the commit body describe what happened in required detail? (this may be none detail)
-* [ ] Are there no breaking changes / are the breaking changes documented?
-* [ ] Are unit tests added? (or not applicable)
-* [ ] Do the edited sections of code match our coding standards
+* Does the PR title clearly describe what the PR does?
+* Does the commit body describe what happened in required detail? (required detail may be none)
+* Are there any breaking changes, and if so, are they documented?
+* Are unit tests added (if applicable)?
+* Does the code follow our coding standards?
   * e.g. naming conventions adhered, no copy/paste, readable, function names describe the behavior
-* [ ] Is the documentation still correct? (function descriptions, readme, etc)
+* Is the documentation still correct? (function descriptions, readme, etc)
+* [ ] I, $reviewer, swear upon pain of feeling shame, that the above have been checked and are correct
 
 Note: Do not press green "squash and merge" or whatever it may say button, add label `automerge` to cause the pr to be automagically merged with the commit message from the PR.


### PR DESCRIPTION
It wasn't clear that the author section shouldn't describe what the PR
does but rather how to test it.

ticket: DV-none
****
<!--commit body should be wrapped at 72 chars as long as this comment-->
<!--
Describe what the PR DOES in the commit body above.
Put notes on how to test in the testing section below.
-->


## Testing notes from the author

<!--
| Test Case                                    | How to tell if it works |
| ---                                          | ---                     |
| appfoo handles a PSM with no path prediction | Outputs empty fields    |
| appfoo handles a PSM with path prediction    | Outputs filled fields   |
-->

## Reviewer Section
* Does the PR title clearly describe what the PR does?
* Does the commit body describe what happened in required detail? (required detail may be none)
* Are there any breaking changes, and if so, are they documented?
* Are unit tests added (if applicable)?
* Does the code follow our coding standards?
  * e.g. naming conventions adhered, no copy/paste, readable, function names describe the behavior
* Is the documentation still correct? (function descriptions, readme, etc)
* [x] I, $reviewer, swear upon pain of feeling shame, that the above have been checked and are correct

Note: Do not press green "squash and merge" or whatever it may say button, add label `automerge` to cause the pr to be automagically merged with the commit message from the PR.


